### PR TITLE
The wrappers for NodeSet and Node were useless

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,12 +16,15 @@ pub struct XPathObject {
     user2: *const c_void,
     index2: c_int
 }
+/// The nodeset
 #[allow(dead_code)]
 pub struct NodeSet {
-    pub node_nr: c_int,
+    node_nr: c_int,
     node_max: c_int,
-    pub node_tab: *mut Node
+    node_tab: *mut Node
 }
+
+/// A node from the nodeset
 #[allow(dead_code)]
 pub struct Node {
     private: *const c_void,
@@ -79,6 +82,22 @@ impl XPathObject {
                 ptr::null()
             } else {
                 result
+            }
+        }
+    }
+}
+
+
+impl<'a> NodeSet {
+    /// Gets a vector of nodes from the NodeSet
+    pub fn get_nodes(&'a self) -> Vec<&'a Node> {
+        unsafe {
+            let node_ptr = self.node_tab;
+            if node_ptr.is_null() {
+                vec![]
+            } else {
+                range(0, self.node_nr).map(
+                    |off| &*self.node_tab.clone().offset(off as int)).collect()
             }
         }
     }

--- a/src/xpath_object.rs
+++ b/src/xpath_object.rs
@@ -1,4 +1,7 @@
 // -*- flycheck-rust-crate-root: "lib.rs" -*-
+pub use super::ffi::NodeSet;
+pub use super::ffi::Node;
+
 use ffi = super::ffi;
 
 use std::kinds::marker::ContravariantLifetime;
@@ -13,46 +16,20 @@ struct XPathObjectWrapper {
     xpath_object: *const ffi::XPathObject,
 }
 
-/// The nodeset
-pub struct NodeSet<'a> {
-    node_set: &'a ffi::NodeSet,
-}
-
-/// A node from the document
-pub struct Node<'a> {
-    node: &'a ffi::Node,
-}
-
 impl<'a> XPathObject<'a> {
     /// Gets a nodeset from the xpathobject
-    pub fn get_node_set(&'a self) -> Option<NodeSet<'a>> {
+    pub fn get_node_set(&'a self) -> Option<&'a NodeSet> {
         unsafe {
             let node_set_ptr = (*self.wrapper.xpath_object).node_set;
             if node_set_ptr.is_null() {
                 None
             } else {
-                Some(NodeSet { node_set: &*node_set_ptr })
+                Some(&*node_set_ptr)
             }
         }
     }
 }
 
-impl<'a> NodeSet<'a> {
-    /// Gets a vector of nodes from the NodeSet
-    pub fn get_nodes(&'a self) -> Vec<Node<'a>> {
-        unsafe {
-            let node_ptr = self.node_set.node_tab;
-            if node_ptr.is_null() {
-                vec![]
-            } else {
-                range(0, self.node_set.node_nr).map(
-                    |off| Node {
-                        node: &*self.node_set.node_tab.clone().offset(off as int)
-                    }).collect()
-            }
-        }
-    }
-}
 
 pub fn from_raw_context<'a>(context: *const ffi::Context,
                         xpath: &str) -> Option<XPathObject<'a>> {


### PR DESCRIPTION
Since I'm always getting references to them, there's no need for
wrappers. I don't need ownership, and they don't need destructors.
